### PR TITLE
Tracker: added anilist

### DIFF
--- a/src/SourceUpdates/testSourceCode.ts
+++ b/src/SourceUpdates/testSourceCode.ts
@@ -1,5 +1,4 @@
-import fetchMangaKakalot from './MangaKakalot';
-import fetchMangaFox from './MangaFox';
+import fetchAnilist from '../Trackers/anilist';
 
 if (require.main === module) {
     main();
@@ -8,6 +7,7 @@ if (require.main === module) {
 async function main(): Promise<void> {
     console.clear();
     // console.log(await fetchMangaKakalot());
-    const mangaFox = await fetchMangaFox();
-    console.log(mangaFox);
+    const anilist = await fetchAnilist('kingbri');
+    console.log(anilist);
+    console.log(anilist.length);
 }

--- a/src/Trackers/anilist.ts
+++ b/src/Trackers/anilist.ts
@@ -1,0 +1,32 @@
+import anilist from 'anilist-node';
+import { removeExtraChars } from '../utils';
+
+export default async function fetchAnilist(username: string): Promise<Array<string>> {
+    const userTitles: Array<string> = [];
+
+    const Anilist = new anilist();
+
+    await Anilist.lists.manga(username).then((data) => {
+        const profile: Array<any> = data;
+
+        for (const element of profile) {
+            if (element.name != 'Reading') {
+                continue;
+            }
+            const entry = element.entries;
+
+            for (const elem of entry) {
+                const titleArr = elem.media.title;
+                if (titleArr.english == null) {
+                    const title = removeExtraChars(titleArr.romaji);
+                    userTitles.push(title);
+                } else {
+                    const title = removeExtraChars(titleArr.english);
+                    userTitles.push(title);
+                }
+            }
+        }
+    });
+
+    return userTitles;
+}


### PR DESCRIPTION
Added fetching of titles from an Anilist.co user account. The titles are fetched from inside the 'Reading' list of the the Manga Library of the user.
For the titles to be scraped, it is required that the account in question is public and is accessible without any special permission from the user. 
The titles are run through the removeExtraChars function and returned in a form of array of string